### PR TITLE
Create mobile styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"eslint-plugin-prettier": "^4.0.0",
 		"postcss-mixins": "^9.0.2",
 		"postcss-nesting": "^11.2.2",
+		"postcss-simple-vars": "^7.0.1",
 		"prettier": "^2.5.1",
 		"typescript": "^5.0.4",
 		"vite": "^4.4.7"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,5 +4,6 @@ module.exports = {
 		require("autoprefixer"),
 		require("postcss-nesting"),
 		require("cssnano")({ preset: ["default", { discardComments: { removeAll: true } }] }),
+		require("postcss-simple-vars"),
 	],
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -20,12 +20,8 @@ export const Button = ({ className, disabled, onClick, progress, text }: IProps)
 					left: f * 100 + "%",
 			  };
 	return (
-		<div className={cx([enabled ? undefined : s.disabledContainer])}>
-			<button
-				className={cx([className, s.button, enabled ? undefined : s.disabledButton])}
-				disabled={!enabled}
-				onClick={onClick}
-			>
+		<div className={cx([s.container, className, enabled ? undefined : s.disabledContainer])}>
+			<button className={cx([s.button, enabled ? undefined : s.disabledButton])} disabled={!enabled} onClick={onClick}>
 				<div className={s.backgroundProgress} style={progressStyle} />
 				{text}
 			</button>

--- a/src/components/Button/styles.module.css
+++ b/src/components/Button/styles.module.css
@@ -1,5 +1,11 @@
 @import "../../styles/mixins/index.css";
 
+.container {
+	display: flex;
+	width: 300px;
+	flex: 0 1 300px;
+}
+
 .disabledContainer {
 	cursor: not-allowed;
 }
@@ -7,6 +13,7 @@
 .button {
 	@mixin type-style-body;
 
+	flex: 1;
 	display: flex;
 	justify-content: center;
 	text-transform: uppercase;

--- a/src/components/CommandFooter/styles.module.css
+++ b/src/components/CommandFooter/styles.module.css
@@ -4,7 +4,8 @@
 	@mixin type-style-footer;
 
 	display: flex;
+	flex: 0 1 50%;
 	color: var(--color-theme-text);
-	margin-top: var(--size-margin-common);
-	padding: 0px var(--size-margin-common);
+	padding: var(--size-margin-common) var(--size-margin-common) 0;
+	align-items: flex-start;
 }

--- a/src/components/CommandFooter/styles.module.css
+++ b/src/components/CommandFooter/styles.module.css
@@ -6,4 +6,5 @@
 	display: flex;
 	color: var(--color-theme-text);
 	margin-top: var(--size-margin-common);
+	padding: 0px var(--size-margin-common);
 }

--- a/src/components/CommandHeader/styles.module.css
+++ b/src/components/CommandHeader/styles.module.css
@@ -4,7 +4,8 @@
 	@mixin type-style-title;
 
 	display: flex;
+	flex: 0 1 50%;
 	color: var(--color-theme-text);
-	margin-bottom: var(--size-margin-common);
-	padding: 0px var(--size-margin-common);
+	padding: 0px var(--size-margin-common) var(--size-margin-common);
+	align-items: flex-end;
 }

--- a/src/components/CommandHeader/styles.module.css
+++ b/src/components/CommandHeader/styles.module.css
@@ -6,4 +6,5 @@
 	display: flex;
 	color: var(--color-theme-text);
 	margin-bottom: var(--size-margin-common);
+	padding: 0px var(--size-margin-common);
 }

--- a/src/components/CommandList/index.tsx
+++ b/src/components/CommandList/index.tsx
@@ -8,12 +8,19 @@ import s from "./styles.module.css";
 
 interface IProps {
 	entries: ICommand[];
+	className?: string;
 	selectedIndex?: number;
 	setSelectedIndex?: (index: number) => void;
 	submit?: (index: number) => void;
 }
 
-export const CommandList = ({ entries, selectedIndex, setSelectedIndex, submit }: IProps): JSX.Element | null => {
+export const CommandList = ({
+	className,
+	entries,
+	selectedIndex,
+	setSelectedIndex,
+	submit,
+}: IProps): JSX.Element | null => {
 	const selectedIndexRef = useRef<HTMLDivElement>(null);
 
 	if (entries.length === 0) {
@@ -42,7 +49,7 @@ export const CommandList = ({ entries, selectedIndex, setSelectedIndex, submit }
 	}, [selectedIndexRef.current]);
 
 	return (
-		<div className={s.container}>
+		<div className={cx([className, s.container])}>
 			{entries.map((c, index) => (
 				<div
 					ref={index === selectedIndexClean ? selectedIndexRef : undefined}

--- a/src/components/CommandPage/index.tsx
+++ b/src/components/CommandPage/index.tsx
@@ -129,7 +129,6 @@ export const CommandPage = ({ params: { slug } }: IProps): JSX.Element => {
 				/>
 				<div className={s.buttonRow}>
 					<Button
-						className={s.button}
 						text={encoder.inited ? "Start" : "Initializing..."}
 						onClick={handleStart}
 						disabled={!canClickStart}
@@ -140,7 +139,7 @@ export const CommandPage = ({ params: { slug } }: IProps): JSX.Element => {
 				{canSave ? (
 					<div className={s.buttonRow}>
 						{encoder.job?.outputFileNames.map((filename) => (
-							<Button className={s.button} text={`Save ${filename}`} onClick={() => handleSaveOutputFile(filename)} />
+							<Button text={`Save ${filename}`} onClick={() => handleSaveOutputFile(filename)} />
 						))}
 					</div>
 				) : null}

--- a/src/components/CommandPage/styles.module.css
+++ b/src/components/CommandPage/styles.module.css
@@ -36,7 +36,15 @@
 
 	color: var(--color-theme-text);
 	margin: 0;
-	padding: var(--size-margin-common) 0;
+	padding: var(--size-margin-common-half) 0;
+	text-align: left;
+
+	margin-right: calc(var(--size-margin-common-half) + var(--size-margin-common-double));
+
+	@mixin for-size-medium-plus {
+		padding: var(--size-margin-common) 0;
+		margin-right: calc(var(--size-margin-common) + var(--size-margin-common-double));
+	}
 }
 
 .tags {
@@ -61,16 +69,24 @@
 	margin: 0;
 	padding: 0;
 	position: absolute;
-	right: var(--size-margin-common-double);
-	top: var(--size-margin-common-double);
 	user-select: none;
-
 	background-color: transparent;
 	border-color: transparent;
 	cursor: pointer;
 
 	width: var(--size-margin-common-double);
 	height: var(--size-margin-common-double);
+
+	top: var(--size-margin-common);
+	right: var(--size-margin-common);
+
+	@mixin for-size-medium-plus {
+		width: var(--size-margin-common-double);
+		height: var(--size-margin-common-double);
+		top: var(--size-margin-common-double);
+		right: var(--size-margin-common-double);
+	}
+
 
 	& .lines {
 		stroke: currentColor;
@@ -85,10 +101,8 @@
 	padding-bottom: var(--size-margin-common);
 	width: 100%;
 	display: flex;
+	flex-direction: row;
 	justify-content: center;
 	gap: var(--size-margin-common);
-}
-
-.button {
-	width: 300px;
+	flex-wrap: wrap;
 }

--- a/src/components/CommandPage/styles.module.css
+++ b/src/components/CommandPage/styles.module.css
@@ -8,20 +8,36 @@
 	flex-direction: column;
 	justify-content: flex-start;
 	align-items: center;
-	padding: 100px 100px;
+	padding: 0px 0px;
+	background-color: var(--color-theme-command-background);
+
+	@mixin for-size-medium-plus {
+		background-color: transparent;
+		padding: 80px 80px;
+	}
+
+	@mixin for-size-large-plus {
+		padding: 110px 110px;
+	}
 }
 
 .box {
 	width: 100%;
 	background-color: var(--color-theme-command-background);
-	box-shadow: 0 0px 3px var(--color-theme-command-shadow);
 	display: flex;
 	align-items: flex-start;
 	flex-direction: column;
-	border: 1px solid var(--color-theme-command-border);
-	border-radius: var(--size-command-border-radius);
-	padding: var(--size-margin-common) var(--size-margin-common-double);
 	position: relative;
+	padding: var(--size-margin-common-half) var(--size-margin-common);
+
+	@mixin for-size-medium-plus {
+		height: auto;
+		box-shadow: 0 0px 3px var(--color-theme-command-shadow);
+		border: 1px solid var(--color-theme-command-border);
+		border-radius: var(--size-command-border-radius);
+
+		padding: var(--size-margin-common) var(--size-margin-common-double);
+	}
 
 	.hr {
 		width: 100%;

--- a/src/components/CommandSearch/index.tsx
+++ b/src/components/CommandSearch/index.tsx
@@ -4,6 +4,7 @@ import cx from "classnames";
 import { Icons } from "../Icons";
 import { CommandList } from "../CommandList";
 import Commands, { ICommand } from "../../utils/commands/Commands";
+import { useWindowSize } from "../../utils/hooks/useViewportWidth";
 
 import s from "./styles.module.css";
 
@@ -88,6 +89,12 @@ export const CommandSearch = ({ onSelectCommand }: IProps): JSX.Element => {
 		}
 	}, [currentListIndex, searchResults.length]);
 
+	const windowSize = useWindowSize();
+	const useSmallPlaceholder = windowSize.width < 630;
+	const placeholder = useSmallPlaceholder
+		? "Enter keywords or a command"
+		: 'Enter keywords or a command (for example, "Mute a video")';
+
 	const clearVisible = currentValue.length > 0;
 
 	return (
@@ -97,7 +104,7 @@ export const CommandSearch = ({ onSelectCommand }: IProps): JSX.Element => {
 					className={s.input}
 					ref={inputRef}
 					maxLength={300}
-					placeholder={'Enter keywords or a command (for example, "Mute a video")'}
+					placeholder={placeholder}
 					type={"text"}
 					autoComplete={"off"}
 					autoCapitalize={"off"}

--- a/src/components/CommandSearch/index.tsx
+++ b/src/components/CommandSearch/index.tsx
@@ -16,6 +16,7 @@ export const CommandSearch = ({ onSelectCommand }: IProps): JSX.Element => {
 	const [currentValue, setCurrentValue] = useState<string>("");
 	const [currentListIndex, setCurrentListIndex] = useState<number | undefined>(undefined);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const [inputHasFocus, setInputHasFocus] = useState(false);
 
 	const searchResults: ICommand[] = useMemo(() => {
 		return currentValue ? Commands.getWithSearch(currentValue) : [];
@@ -38,6 +39,14 @@ export const CommandSearch = ({ onSelectCommand }: IProps): JSX.Element => {
 		const newValue = (e.target as HTMLInputElement | undefined)?.value ?? "";
 		setCurrentValue(newValue);
 		setCurrentListIndex(undefined);
+	}, []);
+
+	const handleInputFocus = useCallback(() => {
+		setInputHasFocus(true);
+	}, []);
+
+	const handleInputBlur = useCallback(() => {
+		setInputHasFocus(false);
 	}, []);
 
 	const handleInputKeyDown = useCallback(
@@ -98,8 +107,8 @@ export const CommandSearch = ({ onSelectCommand }: IProps): JSX.Element => {
 	const clearVisible = currentValue.length > 0;
 
 	return (
-		<div className={s.container}>
-			<form className={s.form} onSubmit={handleFormSubmit}>
+		<div className={cx([s.container, inputHasFocus ? s.focused : undefined])}>
+			<form className={cx([s.form, inputHasFocus ? s.focused : undefined])} onSubmit={handleFormSubmit}>
 				<input
 					className={s.input}
 					ref={inputRef}
@@ -110,6 +119,8 @@ export const CommandSearch = ({ onSelectCommand }: IProps): JSX.Element => {
 					autoCapitalize={"off"}
 					autocorrect={"off"}
 					onInput={handleInput}
+					onFocus={handleInputFocus}
+					onBlur={handleInputBlur}
 					onKeyDown={handleInputKeyDown}
 					value={currentValue}
 					autoFocus
@@ -119,6 +130,7 @@ export const CommandSearch = ({ onSelectCommand }: IProps): JSX.Element => {
 				</button>
 			</form>
 			<CommandList
+				className={cx([s.list, inputHasFocus ? s.listFocused : undefined])}
 				entries={searchResults}
 				selectedIndex={visiblySelectedListIndex}
 				setSelectedIndex={setCurrentListIndex}

--- a/src/components/CommandSearch/styles.module.css
+++ b/src/components/CommandSearch/styles.module.css
@@ -1,19 +1,33 @@
 @import "../../styles/mixins/index.css";
 
+$field-height: calc(1.2em + 16px + 12px);
+
 .container {
 	margin: 0;
 	width: calc(100% - var(--size-margin-common-double) * 2);
 	max-width: 700px;
 	display: flex;
+	flex: 0 0 auto;
 	flex-direction: column;
 	position: relative;
+
+	transition: max-width 0.2s ease-out, width 0.2s ease-out, transform 0.3s ease-in;
+
+	@mixin for-size-small-minus {
+		&.focused {
+			max-width: 100%;
+			width: 100%;
+			transform: translateY(calc(-50vh + calc($field-height / 2)));
+			transform: translateY(calc(-50dvh + calc($field-height / 2)));
+		}
+	}
 }
 
 .form {
 	appearance: none;
 	outline: none;
 	padding: 0;
-	margin: 0 auto;
+	margin: 0;
 	width: 100%;
 	background-color: var(--color-theme-input-background);
 	box-shadow: 0 1px 3px var(--color-theme-input-shadow);
@@ -45,6 +59,15 @@
 		color: var(--color-theme-input-text);
 		opacity: var(--opacity-placeholder);
 	}
+}
+
+.list {
+	transition: max-height 0.2s ease-out;
+}
+
+.listFocused {
+	max-height: calc(100vh - $field-height);
+	max-height: calc(100dvh - $field-height);
 }
 
 .clear {

--- a/src/components/CommandSearch/styles.module.css
+++ b/src/components/CommandSearch/styles.module.css
@@ -2,7 +2,7 @@
 
 .container {
 	margin: 0;
-	width: 100%;
+	width: calc(100% - var(--size-margin-common-double) * 2);
 	max-width: 700px;
 	display: flex;
 	flex-direction: column;

--- a/src/components/EncoderJobStatus/index.tsx
+++ b/src/components/EncoderJobStatus/index.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { useMemo } from "preact/hooks";
 
 import { JobStatus, TEncoderJob } from "../../utils/ffmpeg/Encoder";
@@ -33,15 +34,15 @@ export const EncoderJobStatus = ({ job }: IProps): JSX.Element => {
 		}
 	}, [job.progress, job.status]);
 
-	const labelInfo = useMemo(() => {
+	const labelInfos = useMemo(() => {
 		if (job.status === JobStatus.InProgressTranscoding || job.status === JobStatus.Finished) {
 			const frames = job.progressStats.frames.toString(10) + " frames";
 			const time = Math.floor(job.progressStats.time * 10) / 10 + " sec";
 			const size = Math.floor(job.progressStats.size / 1000) + " kB";
 			const bitrate = (job.progressStats.bitrate ? job.progressStats.bitrate / 1000 : "?") + " kbps";
-			return `${frames} ‧ ${time} ‧ ${size} ‧ ${bitrate}`;
+			return [frames, time, size, bitrate];
 		} else {
-			return "";
+			return [];
 		}
 	}, [job.status, job.progressStats]);
 
@@ -57,7 +58,30 @@ export const EncoderJobStatus = ({ job }: IProps): JSX.Element => {
 		<div className={s.container}>
 			<div className={s.box}>
 				<div className={s.label}>{label}</div>
-				<div className={s.labelInfo}>{labelInfo}</div>
+				<div className={cx([s.labelInfo, s.showWhenTiny])}>
+					{labelInfos.map((l, i) => (
+						<>
+							{i > 0 ? <br /> : null}
+							<span className={s.labelInfoEntry}>{l}</span>
+						</>
+					))}
+				</div>
+				<div className={cx([s.labelInfo, s.showWhenSmall])}>
+					{labelInfos.map((l, i) => (
+						<>
+							{i > 0 ? i % 2 === 1 ? <>{" ‧ "}</> : <br /> : null}
+							<span className={s.labelInfoEntry}>{l}</span>
+						</>
+					))}
+				</div>
+				<div className={cx([s.labelInfo, s.showWhenMediumPlus])}>
+					{labelInfos.map((l, i) => (
+						<>
+							{i > 0 ? <>{" ‧ "}</> : null}
+							<span className={s.labelInfoEntry}>{l}</span>
+						</>
+					))}
+				</div>
 				<div key={job.status} className={s.foregroundBar} style={progressStyle} />
 			</div>
 		</div>

--- a/src/components/EncoderJobStatus/styles.module.css
+++ b/src/components/EncoderJobStatus/styles.module.css
@@ -9,11 +9,20 @@
 .box {
 	background-color: var(--color-theme-code-background);
 	width: 100%;
-	height: 40px;
 	position: relative;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+
+	height: 120px;
+
+	@mixin for-size-small-plus {
+		height: 80px;
+	}
+
+	@mixin for-size-medium-plus {
+		height: 40px;
+	}
 }
 
 .label {
@@ -30,8 +39,32 @@
 	margin: 0 1em;
 	color: var(--color-theme-text);
 	text-align: right;
+	white-space: nowrap;
 }
 
+.labelInfoEntry {
+	white-space: nowrap;
+}
+
+.showWhenTiny {
+	display: none;
+	@mixin for-size-tiny-only {
+		display: inline;
+	}
+}
+
+.showWhenSmall {
+	display: none;
+	@mixin for-size-small-only {
+		display: inline;
+	}
+}
+.showWhenMediumPlus {
+	display: none;
+	@mixin for-size-medium-plus {
+		display: inline;
+	}
+}
 
 .foregroundBar {
 	background-color: var(--color-theme-code-text);

--- a/src/styles/mixins/index.css
+++ b/src/styles/mixins/index.css
@@ -1,1 +1,2 @@
+@import "./queries.css";
 @import "./type.css";

--- a/src/styles/mixins/queries.css
+++ b/src/styles/mixins/queries.css
@@ -52,3 +52,11 @@ $screen-large-min-minus1: 1279px;
 		@mixin-content;
 	}
 }
+
+/* Avoid using these */
+
+@define-mixin for-size-small-minus {
+	@media (max-width: $screen-medium-min-minus1) {
+		@mixin-content;
+	}
+}

--- a/src/styles/mixins/queries.css
+++ b/src/styles/mixins/queries.css
@@ -1,0 +1,54 @@
+$screen-small-min: 470px;
+$screen-small-min-minus1: 469px;
+$screen-medium-min: 960px;
+$screen-medium-min-minus1: 959px;
+$screen-large-min: 1280px;
+$screen-large-min-minus1: 1279px;
+
+@define-mixin for-orientation-landscape {
+	@media only screen and (orientation: landscape) {
+		@mixin-content;
+	}
+}
+
+@define-mixin for-orientation-portrait {
+	@media only screen and (orientation: portrait) {
+		@mixin-content;
+	}
+}
+
+@define-mixin for-size-tiny-only {
+	@media (max-width: $screen-small-min-minus1) {
+		@mixin-content;
+	}
+}
+
+@define-mixin for-size-small-plus {
+	@media (min-width: $screen-small-min) {
+		@mixin-content;
+	}
+}
+
+@define-mixin for-size-small-only {
+	@media (min-width: $screen-small-min) and (max-width: $screen-medium-min-minus1) {
+		@mixin-content;
+	}
+}
+
+@define-mixin for-size-medium-plus {
+	@media (min-width: $screen-medium-min) {
+		@mixin-content;
+	}
+}
+
+@define-mixin for-size-medium-only {
+	@media (min-width: $screen-medium-min) and (max-width: $screen-large-min-minus1) {
+		@mixin-content;
+	}
+}
+
+@define-mixin for-size-large-plus {
+	@media (min-width: $screen-large-min) {
+		@mixin-content;
+	}
+}

--- a/src/utils/hooks/useViewportWidth.ts
+++ b/src/utils/hooks/useViewportWidth.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useState } from "preact/hooks";
+
+export const useWindowSize = (): { width: number; height: number } => {
+	const [size, setSize] = useState({ width: window.innerWidth, height: window.innerHeight });
+
+	const handleResize = useCallback(() => {
+		setSize({ width: window.innerWidth, height: window.innerHeight });
+	}, []);
+
+	useEffect(() => {
+		window.addEventListener("resize", handleResize);
+		return () => {
+			window.removeEventListener("reisze", handleResize);
+		};
+	}, []);
+
+	return size;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,7 +1831,7 @@ postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11, postcss-select
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-simple-vars@^7.0.0:
+postcss-simple-vars@^7.0.0, postcss-simple-vars@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-7.0.1.tgz#836b3097a54dcd13dbd3c36a5dbdd512fad2954c"
   integrity sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==


### PR DESCRIPTION
A number of changes to make the app more friendly to mobile users, including new styles, sizes, and some adaptive UX for the search screen where the search input moves up and the results take over the available space.

| Before | After |
|--|--|
| <img src="https://github.com/zeh/ffmpeg.app/assets/49529/e3a1f38b-d6c5-43f5-b936-f1b6b011540b" width="140"> | <img src="https://github.com/zeh/ffmpeg.app/assets/49529/be9aa931-19d6-4491-be64-6921fd212419" width="140"> |
| <img src="https://github.com/zeh/ffmpeg.app/assets/49529/cf915869-57dd-4eeb-9bee-a1b448e3d416" width="140"> | <img src="https://github.com/zeh/ffmpeg.app/assets/49529/5c261b50-5a25-4ec9-addc-abd212e5e055" width="140"> |
|  <img src="https://github.com/zeh/ffmpeg.app/assets/49529/725b75eb-ea6e-48b4-b74c-f51cee37bf87" width="140"> | <img src="https://github.com/zeh/ffmpeg.app/assets/49529/f51cdaea-e930-43cd-9adb-992fde721beb" width="140"> |

Closes #16.